### PR TITLE
Add use-case simulation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project contains two Spring Boot services used to demo sensor data and garbage collection monitoring.
 
 Para una descripción en español del servicio interno de monitoreo de residuos industriales consulte [docs/Propuesta_Servicio_TEYMA.md](docs/Propuesta_Servicio_TEYMA.md).
+Para ver una guia de simulacion consulta [docs/Simulacion_Casos_de_Uso.md](docs/Simulacion_Casos_de_Uso.md).
 
 ## Modules
 

--- a/docs/Simulacion_Casos_de_Uso.md
+++ b/docs/Simulacion_Casos_de_Uso.md
@@ -1,0 +1,28 @@
+# Simulación de Casos de Uso Prioritarios
+
+Este documento describe los cambios sugeridos para replicar escenarios de monitoreo IoT siguiendo la arquitectura del repositorio.
+
+## 1. Sensores IoT y Red de Comunicación
+- Generar lecturas simuladas usando scripts o `curl` que envíen datos HTTP al servicio `sensor-api`.
+- Utilizar el API `/api/readings` como punto de ingreso, sustituyendo el envío real desde dispositivos LoRaWAN/NB‑IoT.
+
+## 2. Gateway / Concentrador
+- El gateway se puede emular ejecutando un proceso que lea datos de sensores (o el simulador) y los reenvíe al backend.
+- Para simplificar, se emplean llamadas REST o eventos programados en lugar de MQTT.
+
+## 3. Backend IoT (microservicios Spring Boot)
+- Los módulos `sensor-api` y `recoleccion` del repositorio representan microservicios independientes.
+- Mantener la ingesta a través de los controladores REST ya presentes y almacenar los registros en las bases de datos definidas por JPA/H2.
+- Habilitar endpoints adicionales si se requieren consultas más específicas de contenedores o proyecciones históricas.
+
+## 4. Frontend / Dashboard
+- Puede consumirse la API desde un cliente externo o mediante herramientas como Postman para validar el flujo principal.
+- La ruta `/recoleccion/export` permite obtener datos en CSV que pueden cargarse en Power BI para generar reportes.
+
+## 5. Flujo Principal del Caso de Uso
+1. **Simulación de sensores** que envían datos a `/api/readings` y `/recoleccion`.
+2. **El gateway simulado** reenvía los datos de manera programada.
+3. **Los microservicios** persisten la información y ofrecen los endpoints para consulta y exportación.
+4. **El usuario** visualiza resultados en un dashboard o mediante herramientas de análisis.
+
+Este enfoque aprovecha el código existente y minimiza dependencias, priorizando el flujo principal de la aplicación.


### PR DESCRIPTION
## Summary
- document how to simulate main use cases for sensors, gateway, backend and dashboard
- link the new guide from the root README

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml test` *(fails: Could not transfer artifact)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68545d0f2170832986bd128201d2bed9