### PR TITLE
Add MongoDB feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project contains two Spring Boot services used to demo sensor data and garbage collection monitoring.
 
 Para una descripción en español del servicio interno de monitoreo de residuos industriales consulte [docs/Propuesta_Servicio_TEYMA.md](docs/Propuesta_Servicio_TEYMA.md).
+Para ver una guia de simulacion consulta [docs/Simulacion_Casos_de_Uso.md](docs/Simulacion_Casos_de_Uso.md).
 
 ## Modules
 
@@ -10,6 +11,9 @@ Para una descripción en español del servicio interno de monitoreo de residuos 
 - `recoleccion` – garbage collection monitoring service that preloads random events on startup.
 
 Both modules use the Maven wrapper found in `sensor-api/mvnw`.
+The `sensor-api` service supports SQL or MongoDB storage. Set `sensor.storage.type=mongo`
+in `sensor-api/src/main/resources/application.properties` (or environment variable)
+to enable MongoDB.
 
 ## Running locally
 

--- a/docs/Simulacion_Casos_de_Uso.md
+++ b/docs/Simulacion_Casos_de_Uso.md
@@ -1,0 +1,38 @@
+# Simulación de Casos de Uso Prioritarios
+
+Este documento describe los cambios sugeridos para replicar escenarios de monitoreo IoT siguiendo la arquitectura del repositorio.
+
+## 1. Sensores IoT y Red de Comunicación
+- Generar lecturas simuladas usando scripts o `curl` que envíen datos HTTP al servicio `sensor-api`.
+- Utilizar el API `/api/readings` como punto de ingreso, sustituyendo el envío real desde dispositivos LoRaWAN/NB‑IoT.
+
+## 2. Gateway / Concentrador
+- El gateway se puede emular ejecutando un proceso que lea datos de sensores (o el simulador) y los reenvíe al backend.
+- Para simplificar, se emplean llamadas REST o eventos programados en lugar de MQTT.
+
+## 3. Backend IoT (microservicios Spring Boot)
+- Los módulos `sensor-api` y `recoleccion` del repositorio representan microservicios independientes.
+- Mantener la ingesta a través de los controladores REST ya presentes y almacenar los registros en las bases de datos definidas por JPA/H2.
+- Por defecto, `sensor-api` usa H2 en memoria. Se puede habilitar almacenamiento en MongoDB
+  estableciendo `sensor.storage.type=mongo` en las propiedades de la aplicación.
+- Habilitar endpoints adicionales si se requieren consultas más específicas de contenedores o proyecciones históricas.
+
+## 4. Frontend / Dashboard
+- Puede consumirse la API desde un cliente externo o mediante herramientas como Postman para validar el flujo principal.
+- La ruta `/recoleccion/export` permite obtener datos en CSV que pueden cargarse en Power BI para generar reportes.
+
+## 5. Flujo Principal del Caso de Uso
+1. **Simulación de sensores** que envían datos a `/api/readings` y `/recoleccion`.
+2. **El gateway simulado** reenvía los datos de manera programada.
+3. **Los microservicios** persisten la información y ofrecen los endpoints para consulta y exportación.
+4. **El usuario** visualiza resultados en un dashboard o mediante herramientas de análisis.
+
+Este enfoque aprovecha el código existente y minimiza dependencias, priorizando el flujo principal de la aplicación.
+
+## 6. Prueba de simulación
+
+El proyecto incluye un test llamado `SimulacionCasosDeUsoTests` que genera el
+archivo `simulacion-containers.csv` con las lecturas de cinco contenedores que
+se llenan a ritmos distintos. En cada paso se registran los niveles de llenado
+y se marca con `FULL` cuando un contenedor alcanza el 100 %. Este CSV permite
+visualizar de forma sencilla la evolución y los eventos de llenado.

--- a/sensor-api/pom.xml
+++ b/sensor-api/pom.xml
@@ -34,10 +34,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-mongodb</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/sensor-api/src/main/java/com/example/sensorapi/DataLoader.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/DataLoader.java
@@ -1,7 +1,7 @@
 package com.example.sensorapi;
 
 import com.example.sensorapi.model.SensorReading;
-import com.example.sensorapi.repository.SensorReadingRepository;
+import com.example.sensorapi.repository.SensorReadingStore;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +12,7 @@ import java.time.Month;
 @Configuration
 public class DataLoader {
     @Bean
-    CommandLineRunner loadData(SensorReadingRepository repository) {
+    CommandLineRunner loadData(SensorReadingStore repository) {
         return args -> {
             repository.save(new SensorReading(1L, 11.10, LocalDateTime.of(2025, Month.JUNE, 16, 1, 44, 23, 321178000)));
             repository.save(new SensorReading(1L, 11.69, LocalDateTime.of(2025, Month.JUNE, 16, 2, 14, 23, 321178000)));

--- a/sensor-api/src/main/java/com/example/sensorapi/StorageConfig.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/StorageConfig.java
@@ -1,0 +1,21 @@
+package com.example.sensorapi;
+
+import com.example.sensorapi.repository.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfig {
+    @Bean
+    @ConditionalOnProperty(name = "sensor.storage.type", havingValue = "sql", matchIfMissing = true)
+    public SensorReadingStore sqlStore(SensorReadingRepository repository) {
+        return new SqlSensorReadingStore(repository);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "sensor.storage.type", havingValue = "mongo")
+    public SensorReadingStore mongoStore(SensorReadingMongoRepository repository) {
+        return new MongoSensorReadingStore(repository);
+    }
+}

--- a/sensor-api/src/main/java/com/example/sensorapi/controller/SensorReadingController.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/controller/SensorReadingController.java
@@ -1,7 +1,7 @@
 package com.example.sensorapi.controller;
 
 import com.example.sensorapi.model.SensorReading;
-import com.example.sensorapi.repository.SensorReadingRepository;
+import com.example.sensorapi.repository.SensorReadingStore;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,10 +12,10 @@ import java.util.List;
 @RequestMapping("/api/readings")
 public class SensorReadingController {
 
-    private final SensorReadingRepository repository;
+    private final SensorReadingStore store;
 
-    public SensorReadingController(SensorReadingRepository repository) {
-        this.repository = repository;
+    public SensorReadingController(SensorReadingStore store) {
+        this.store = store;
     }
 
     @PostMapping
@@ -24,11 +24,11 @@ public class SensorReadingController {
         if (reading.getTimestamp() == null) {
             reading.setTimestamp(LocalDateTime.now());
         }
-        return repository.save(reading);
+        return store.save(reading);
     }
 
     @GetMapping
     public List<SensorReading> findAll() {
-        return repository.findAll();
+        return store.findAll();
     }
 }

--- a/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
@@ -1,11 +1,14 @@
 package com.example.sensorapi.model;
 
 import jakarta.persistence.*;
+import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDateTime;
 
 @Entity
+@Document("sensor_readings")
 public class SensorReading {
-    @Id
+    @jakarta.persistence.Id
+    @org.springframework.data.annotation.Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/MongoSensorReadingStore.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/MongoSensorReadingStore.java
@@ -1,0 +1,23 @@
+package com.example.sensorapi.repository;
+
+import com.example.sensorapi.model.SensorReading;
+
+import java.util.List;
+
+public class MongoSensorReadingStore implements SensorReadingStore {
+    private final SensorReadingMongoRepository repository;
+
+    public MongoSensorReadingStore(SensorReadingMongoRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public SensorReading save(SensorReading reading) {
+        return repository.save(reading);
+    }
+
+    @Override
+    public List<SensorReading> findAll() {
+        return repository.findAll();
+    }
+}

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingMongoRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingMongoRepository.java
@@ -1,0 +1,7 @@
+package com.example.sensorapi.repository;
+
+import com.example.sensorapi.model.SensorReading;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SensorReadingMongoRepository extends MongoRepository<SensorReading, Long> {
+}

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingStore.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingStore.java
@@ -1,0 +1,10 @@
+package com.example.sensorapi.repository;
+
+import com.example.sensorapi.model.SensorReading;
+
+import java.util.List;
+
+public interface SensorReadingStore {
+    SensorReading save(SensorReading reading);
+    List<SensorReading> findAll();
+}

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SqlSensorReadingStore.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SqlSensorReadingStore.java
@@ -1,0 +1,23 @@
+package com.example.sensorapi.repository;
+
+import com.example.sensorapi.model.SensorReading;
+
+import java.util.List;
+
+public class SqlSensorReadingStore implements SensorReadingStore {
+    private final SensorReadingRepository repository;
+
+    public SqlSensorReadingStore(SensorReadingRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public SensorReading save(SensorReading reading) {
+        return repository.save(reading);
+    }
+
+    @Override
+    public List<SensorReading> findAll() {
+        return repository.findAll();
+    }
+}

--- a/sensor-api/src/main/resources/application.properties
+++ b/sensor-api/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.application.name=sensor-api
 spring.h2.console.enabled=true
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.jpa.hibernate.ddl-auto=update
+sensor.storage.type=sql
+spring.data.mongodb.uri=mongodb://localhost:27017/sensors

--- a/sensor-api/src/test/java/com/example/sensorapi/SimulacionCasosDeUsoTests.java
+++ b/sensor-api/src/test/java/com/example/sensorapi/SimulacionCasosDeUsoTests.java
@@ -1,0 +1,44 @@
+package com.example.sensorapi;
+
+import com.example.sensorapi.model.SensorReading;
+import com.example.sensorapi.repository.SensorReadingStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class SimulacionCasosDeUsoTests {
+
+    @Autowired
+    SensorReadingStore repository;
+
+    @Test
+    void simularLlenadoDeContenedores() throws Exception {
+        Path csv = Path.of("simulacion-containers.csv");
+        try (BufferedWriter writer = Files.newBufferedWriter(csv)) {
+            writer.write("timestamp,containerId,level,event\n");
+            int[] rates = {20, 30, 40, 50, 60};
+            LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0);
+            for (int step = 0; step < 5; step++) {
+                for (int i = 0; i < rates.length; i++) {
+                    double level = Math.min(100, rates[i] * (step + 1));
+                    LocalDateTime ts = start.plusHours(step);
+                    SensorReading r = new SensorReading((long) (i + 1), level, ts);
+                    repository.save(r);
+                    String event = level >= 100 && rates[i] * step < 100 ? "FULL" : "";
+                    writer.write(String.format("%s,C%d,%.1f,%s%n", ts, i + 1, level, event));
+                }
+            }
+        }
+        long lines = Files.lines(csv).count();
+        assertTrue(lines >= 26); // header + readings
+        assertTrue(Files.readString(csv).contains("FULL"));
+    }
+}


### PR DESCRIPTION
## Summary
- support MongoDB with a feature flag in `sensor-api`
- document the new flag in the README and usage guide
- implement `StorageConfig` to choose SQL or MongoDB
- refactor sensor API components to use `SensorReadingStore`

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml test` *(fails: Non-resolvable parent POM)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68545d0f2170832986bd128201d2bed9