### PR TITLE
Fix import ordering and remove autowired field

### DIFF
--- a/recoleccion/src/main/java/com/micuota/recoleccion/service/RecoleccionService.java
+++ b/recoleccion/src/main/java/com/micuota/recoleccion/service/RecoleccionService.java
@@ -6,7 +6,6 @@ import com.micuota.recoleccion.repository.RecoleccionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -16,8 +15,11 @@ import java.util.stream.Collectors;
 
 @Service
 public class RecoleccionService {
-    @Autowired
-    private RecoleccionRepository repository;
+    private final RecoleccionRepository repository;
+
+    public RecoleccionService(RecoleccionRepository repository) {
+        this.repository = repository;
+    }
 
 
 


### PR DESCRIPTION
## Summary
- remove redundant `@Autowired` import
- switch `RecoleccionService` to constructor injection and keep imports ordered

## Testing
- `mvn -f recoleccion/pom.xml test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68555ece1c388329aeade45898e679bf