### PR TITLE
Fix duplicate save and update tests

### DIFF
--- a/recoleccion/src/main/java/com/micuota/recoleccion/controller/RecoleccionController.java
+++ b/recoleccion/src/main/java/com/micuota/recoleccion/controller/RecoleccionController.java
@@ -32,13 +32,12 @@ public class RecoleccionController {
     private RecoleccionRepository repository;
 
     @PostMapping
-    public ResponseEntity<String> registrar(@RequestBody RecoleccionDTO dto) {
+    public ResponseEntity<Recoleccion> registrar(@RequestBody RecoleccionDTO dto) {
 
         var saved = service.guardar(dto);
         log.info("Registrada {}", saved);
-        service.guardar(dto);
 
-        return ResponseEntity.ok("Recolección registrada");
+        return ResponseEntity.ok(saved);
     }
 
     @GetMapping("/{contenedorId}")

--- a/recoleccion/src/test/java/com/micuota/recoleccion/RecoleccionControllerTests.java
+++ b/recoleccion/src/test/java/com/micuota/recoleccion/RecoleccionControllerTests.java
@@ -27,7 +27,9 @@ class RecoleccionControllerTests {
         mockMvc.perform(post("/recoleccion")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contenedorId").value("C1"))
+                .andExpect(jsonPath("$.id").exists());
 
         mockMvc.perform(get("/recoleccion/C1"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- fix `RecoleccionController.registrar` to save only once
- return the saved entity in the response
- update controller tests to check returned data

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68555faa3a488329864512a3fcbb43c1