### PR TITLE
Fix SensorReading.getId return type

### DIFF
--- a/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
@@ -27,7 +27,7 @@ public class SensorReading {
         this.timestamp = timestamp;
     }
 
-    public String getId() { return id; }
+    public Long getId() { return id; }
     public Long getContainerId() { return containerId; }
     public void setContainerId(Long containerId) { this.containerId = containerId; }
     public Double getLevelPercentage() { return levelPercentage; }

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingRepository.java
@@ -3,5 +3,5 @@ package com.example.sensorapi.repository;
 import com.example.sensorapi.model.SensorReading;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface SensorReadingRepository extends MongoRepository<SensorReading, String> {
+public interface SensorReadingRepository extends MongoRepository<SensorReading, Long> {
 }


### PR DESCRIPTION
## Summary
- update `getId()` to return `Long`
- align SensorReadingRepository with new `Long` id type

## Testing
- `./one-click-review.sh test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6855606f3a2083298eb00af56afede44