### PR TITLE
Fix repository bean name clash

### DIFF
--- a/sensor-api/src/main/java/com/example/sensorapi/SensorApiApplication.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/SensorApiApplication.java
@@ -2,8 +2,14 @@ package com.example.sensorapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import com.example.sensorapi.repository.jpa.SensorReadingRepository;
+import com.example.sensorapi.repository.mongo.SensorReadingMongoRepository;
 
 @SpringBootApplication
+@EnableJpaRepositories(basePackageClasses = SensorReadingRepository.class)
+@EnableMongoRepositories(basePackageClasses = SensorReadingMongoRepository.class)
 public class SensorApiApplication {
     public static void main(String[] args) {
         SpringApplication.run(SensorApiApplication.class, args);

--- a/sensor-api/src/main/java/com/example/sensorapi/StorageConfig.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/StorageConfig.java
@@ -1,6 +1,10 @@
 package com.example.sensorapi;
 
-import com.example.sensorapi.repository.*;
+import com.example.sensorapi.repository.mongo.SensorReadingMongoRepository;
+import com.example.sensorapi.repository.jpa.SensorReadingRepository;
+import com.example.sensorapi.repository.MongoSensorReadingStore;
+import com.example.sensorapi.repository.SqlSensorReadingStore;
+import com.example.sensorapi.repository.SensorReadingStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/MongoSensorReadingStore.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/MongoSensorReadingStore.java
@@ -1,6 +1,7 @@
 package com.example.sensorapi.repository;
 
 import com.example.sensorapi.model.SensorReading;
+import com.example.sensorapi.repository.mongo.SensorReadingMongoRepository;
 
 import java.util.List;
 

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SensorReadingRepository.java
@@ -1,7 +1,0 @@
-package com.example.sensorapi.repository;
-
-import com.example.sensorapi.model.SensorReading;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface SensorReadingRepository extends MongoRepository<SensorReading, Long> {
-}

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/SqlSensorReadingStore.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/SqlSensorReadingStore.java
@@ -1,6 +1,7 @@
 package com.example.sensorapi.repository;
 
 import com.example.sensorapi.model.SensorReading;
+import com.example.sensorapi.repository.jpa.SensorReadingRepository;
 
 import java.util.List;
 

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/jpa/SensorReadingRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/jpa/SensorReadingRepository.java
@@ -1,0 +1,7 @@
+package com.example.sensorapi.repository.jpa;
+
+import com.example.sensorapi.model.SensorReading;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SensorReadingRepository extends JpaRepository<SensorReading, Long> {
+}

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/mongo/SensorReadingMongoRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/mongo/SensorReadingMongoRepository.java
@@ -1,4 +1,4 @@
-package com.example.sensorapi.repository;
+package com.example.sensorapi.repository.mongo;
 
 import com.example.sensorapi.model.SensorReading;
 import org.springframework.data.mongodb.repository.MongoRepository;


### PR DESCRIPTION
## Summary
- move JPA and Mongo repositories into separate packages
- enable JPA and Mongo repository scanning for their specific packages
- update store classes and configuration with new imports

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml test` *(fails: Non-resolvable parent POM)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685564051b908329957a8cd2f3a041bf