### PR TITLE
Fix Mongo autogeneration error

### DIFF
--- a/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/model/SensorReading.java
@@ -4,14 +4,14 @@ package com.example.sensorapi.model;
 import jakarta.persistence.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Document("sensor_readings")
 public class SensorReading {
     @jakarta.persistence.Id
     @org.springframework.data.annotation.Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id = UUID.randomUUID().toString();
 
     private Long containerId;
 
@@ -27,7 +27,7 @@ public class SensorReading {
         this.timestamp = timestamp;
     }
 
-    public Long getId() { return id; }
+    public String getId() { return id; }
     public Long getContainerId() { return containerId; }
     public void setContainerId(Long containerId) { this.containerId = containerId; }
     public Double getLevelPercentage() { return levelPercentage; }

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/jpa/SensorReadingRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/jpa/SensorReadingRepository.java
@@ -3,5 +3,5 @@ package com.example.sensorapi.repository.jpa;
 import com.example.sensorapi.model.SensorReading;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SensorReadingRepository extends JpaRepository<SensorReading, Long> {
+public interface SensorReadingRepository extends JpaRepository<SensorReading, String> {
 }

--- a/sensor-api/src/main/java/com/example/sensorapi/repository/mongo/SensorReadingMongoRepository.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/repository/mongo/SensorReadingMongoRepository.java
@@ -3,5 +3,5 @@ package com.example.sensorapi.repository.mongo;
 import com.example.sensorapi.model.SensorReading;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface SensorReadingMongoRepository extends MongoRepository<SensorReading, Long> {
+public interface SensorReadingMongoRepository extends MongoRepository<SensorReading, String> {
 }


### PR DESCRIPTION
## Summary
- assign UUID String values to sensor readings for both JPA and MongoDB
- update JPA and Mongo repository definitions for String ids

## Testing
- `./sensor-api/mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6855661fe42083299aa8931080f243c6