### PR TITLE
Fix recoleccion mongo connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To run the whole stack including MongoDB in containers, build the images and sta
 docker compose up --build
 ```
 
-The sensor API will listen on port `8080` and use the `mongo` service as its database. The `recoleccion` service runs on port `8081`.
+The sensor API will listen on port `8080` and use the `mongo` service as its database.
+The `recoleccion` service also connects to the same `mongo` container and runs on port `8081`.
 
 ## Running tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,9 @@ services:
 
   recoleccion:
     build: ./recoleccion
+    environment:
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/recoleccion
+    depends_on:
+      - mongo
     ports:
       - "8081:8081"


### PR DESCRIPTION
## Summary
- configure `recoleccion` service in docker-compose to connect to MongoDB container
- document the connection in README

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml test` *(fails: Network is unreachable)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68556962d9748329bd6a0e742aa8ca4a