### PR TITLE
Add Swagger docs and Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ The `sensor-api` service supports SQL or MongoDB storage. Set `sensor.storage.ty
 in `sensor-api/src/main/resources/application.properties` (or environment variable)
 to enable MongoDB.
 
+## API documentation
+
+Each service exposes an OpenAPI specification and Swagger UI when running locally.
+Visit `http://localhost:8080/swagger-ui.html` for the sensor API and
+`http://localhost:8081/swagger-ui.html` for the garbage collection service.
+You can also import `docs/DatosSensores.postman_collection.json` into Postman to
+try the endpoints.
+
 
 The applications now store their data in MongoDB. Ensure a MongoDB instance is
 available locally on the default port before running the services.

--- a/docs/DatosSensores.postman_collection.json
+++ b/docs/DatosSensores.postman_collection.json
@@ -1,0 +1,74 @@
+{
+  "info": {
+    "name": "Datos Sensores API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Sensor API",
+      "item": [
+        {
+          "name": "List readings",
+          "request": {
+            "method": "GET",
+            "url": "{{sensor_base_url}}/api/readings"
+          }
+        },
+        {
+          "name": "Create reading",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"containerId\": 1,\n  \"levelPercentage\": 50.0,\n  \"timestamp\": \"2025-06-16T00:00:00\"\n}"
+            },
+            "url": "{{sensor_base_url}}/api/readings"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Recoleccion API",
+      "item": [
+        {
+          "name": "Registrar",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contenedorId\": \"A1\",\n  \"lat\": -34.6,\n  \"lon\": -58.4,\n  \"recolectado\": \"2025-06-16T00:00:00\"\n}"
+            },
+            "url": "{{recoleccion_base_url}}/recoleccion"
+          }
+        },
+        {
+          "name": "Historial por contenedor",
+          "request": {
+            "method": "GET",
+            "url": "{{recoleccion_base_url}}/recoleccion/A1"
+          }
+        },
+        {
+          "name": "Exportar CSV",
+          "request": {
+            "method": "GET",
+            "url": "{{recoleccion_base_url}}/recoleccion/export"
+          }
+        },
+        {
+          "name": "Estadisticas",
+          "request": {
+            "method": "GET",
+            "url": "{{recoleccion_base_url}}/recoleccion/estadisticas"
+          }
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {"key": "sensor_base_url", "value": "http://localhost:8080"},
+    {"key": "recoleccion_base_url", "value": "http://localhost:8081"}
+  ]
+}

--- a/recoleccion/pom.xml
+++ b/recoleccion/pom.xml
@@ -17,11 +17,11 @@
     <properties>
         <java.version>17</java.version>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -35,6 +35,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/recoleccion/src/main/java/com/micuota/recoleccion/MonitoreoApplication.java
+++ b/recoleccion/src/main/java/com/micuota/recoleccion/MonitoreoApplication.java
@@ -2,8 +2,11 @@ package com.micuota.recoleccion;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Recoleccion API", version = "v1"))
 public class MonitoreoApplication {
     public static void main(String[] args) {
         SpringApplication.run(MonitoreoApplication.class, args);

--- a/sensor-api/pom.xml
+++ b/sensor-api/pom.xml
@@ -29,11 +29,11 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
     <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -49,12 +49,17 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/sensor-api/src/main/java/com/example/sensorapi/SensorApiApplication.java
+++ b/sensor-api/src/main/java/com/example/sensorapi/SensorApiApplication.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import com.example.sensorapi.repository.jpa.SensorReadingRepository;
 import com.example.sensorapi.repository.mongo.SensorReadingMongoRepository;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackageClasses = SensorReadingRepository.class)
 @EnableMongoRepositories(basePackageClasses = SensorReadingMongoRepository.class)
+@OpenAPIDefinition(info = @Info(title = "Sensor API", version = "v1"))
 public class SensorApiApplication {
     public static void main(String[] args) {
         SpringApplication.run(SensorApiApplication.class, args);


### PR DESCRIPTION
## Summary
- document Swagger endpoints in README
- expose OpenAPI definitions via springdoc in each Spring Boot module
- include Postman collection with basic calls to both services

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml test` *(fails: Non-resolvable parent POM)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68556ff11d888329b37615b8f0a3dd5e