### PR TITLE
Fix cross service test

### DIFF
--- a/recoleccion/src/test/java/com/micuota/recoleccion/CrossServicesIntegrationTest.java
+++ b/recoleccion/src/test/java/com/micuota/recoleccion/CrossServicesIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.micuota.recoleccion;
 
 import com.example.sensorapi.SensorApiApplication;
+import com.example.sensorapi.StorageConfig;
+import com.example.sensorapi.DataLoader;
 import com.example.sensorapi.model.SensorReading;
 import com.micuota.recoleccion.dto.RecoleccionDTO;
 import com.micuota.recoleccion.entity.Recoleccion;
@@ -20,7 +22,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = {SensorApiApplication.class, MonitoreoApplication.class},
+    classes = {
+        SensorApiApplication.class,
+        MonitoreoApplication.class,
+        StorageConfig.class,
+        DataLoader.class
+    },
     properties = {"sensor.storage.type=mongo", "server.port=0"})
 public class CrossServicesIntegrationTest {
 


### PR DESCRIPTION
## Summary
- import `DataLoader` and `StorageConfig` into the integration test
- include those classes in the Spring context for cross-service test

## Testing
- `./sensor-api/mvnw -q -f sensor-api/pom.xml -DskipTests install` *(fails: Non-resolvable parent POM)*
- `./sensor-api/mvnw -q -f recoleccion/pom.xml -DskipTests install` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685585411b388329880c010049c17f47